### PR TITLE
Feature/implement continuously running service

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,19 @@
 
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
-                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
+
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </receiver>
+
+        <receiver
+                android:name=".domain.receivers.UsbAttachedReceiver"
+                android:enabled="true">
+
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_STATE"/>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
 
                 <category android:name="android.intent.category.DEFAULT"/>
             </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         </activity>
 
         <receiver
-                android:name=".domain.BootCompletedReceiver"
+                android:name=".domain.receivers.BootCompletedReceiver"
                 android:enabled="true">
 
             <intent-filter>

--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/FunctionResult.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/FunctionResult.kt
@@ -1,0 +1,15 @@
+package com.matkosmoljan.apps.autousbtethering
+
+
+sealed class FunctionResult<out T> {
+    class Success<T>(val value: T) : FunctionResult<T>()
+    class Failure<T>(val exception: Throwable) : FunctionResult<T>()
+}
+
+fun <T> FunctionResult<T>.fold(
+    onSuccess: (T) -> Unit,
+    onFailure: (Throwable) -> Unit
+) = when (this) {
+    is FunctionResult.Success -> onSuccess(value)
+    is FunctionResult.Failure -> onFailure(exception)
+}

--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/MainActivity.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/MainActivity.kt
@@ -4,7 +4,10 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
+import android.view.View
 import com.matkosmoljan.apps.autousbtethering.domain.TetherSwitch
+import kotlinx.android.synthetic.main.activity_main.*
 import org.koin.android.ext.android.inject
 
 class MainActivity : Activity() {
@@ -20,12 +23,21 @@ class MainActivity : Activity() {
         setContentView(R.layout.activity_main)
 
         tetherSwitch.turnTetheringOn().fold(
-            onSuccess = { finish() },
+            onSuccess = {
+                hideError()
+                finish()
+            }
+            ,
             onFailure = { showError(it) }
         )
     }
 
+    private fun hideError() {
+        errorMessageView.visibility = View.GONE
+    }
+
     private fun showError(exception: Throwable) {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        Log.e("MainActivity", exception.message)
+        errorMessageView.visibility = View.VISIBLE
     }
 }

--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/MainActivity.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/MainActivity.kt
@@ -1,13 +1,13 @@
 package com.matkosmoljan.apps.autousbtethering
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.matkosmoljan.apps.autousbtethering.domain.TetherSwitch
 import org.koin.android.ext.android.inject
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : Activity() {
 
     companion object {
         fun createIntent(context: Context) = Intent(context, MainActivity::class.java)
@@ -19,6 +19,13 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        tetherSwitch.turnTetheringOn()
+        tetherSwitch.turnTetheringOn().fold(
+            onSuccess = { finish() },
+            onFailure = { showError(it) }
+        )
+    }
+
+    private fun showError(exception: Throwable) {
+        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 }

--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/TetherSwitch.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/TetherSwitch.kt
@@ -1,9 +1,10 @@
 package com.matkosmoljan.apps.autousbtethering.domain
 
+import com.matkosmoljan.apps.autousbtethering.FunctionResult
 
 /**
  * Turns USB tethering on. Implementations may vary depending on the Android version used, device etc.
  */
 interface TetherSwitch {
-    fun turnTetheringOn()
+    fun turnTetheringOn(): FunctionResult<Unit>
 }

--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/receivers/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/receivers/BootCompletedReceiver.kt
@@ -1,4 +1,4 @@
-package com.matkosmoljan.apps.autousbtethering.domain
+package com.matkosmoljan.apps.autousbtethering.domain.receivers
 
 import android.content.BroadcastReceiver
 import android.content.Context

--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/receivers/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/receivers/BootCompletedReceiver.kt
@@ -11,6 +11,7 @@ class BootCompletedReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action == ACTION_LOCKED_BOOT_COMPLETED || intent.action == ACTION_BOOT_COMPLETED) {
+            // Start main activity once at boot to check if the tethering has been switched on
             MainActivity
                 .createIntent(context)
                 .let(context::startActivity)

--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/receivers/UsbAttachedReceiver.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/receivers/UsbAttachedReceiver.kt
@@ -1,0 +1,19 @@
+package com.matkosmoljan.apps.autousbtethering.domain.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.matkosmoljan.apps.autousbtethering.domain.TetherSwitch
+import com.matkosmoljan.apps.autousbtethering.domain.shell.ShellTetherSwitch
+
+
+class UsbAttachedReceiver : BroadcastReceiver() {
+
+    private val tetherSwitch: TetherSwitch = ShellTetherSwitch()
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == "android.hardware.usb.action.USB_STATE") {
+            tetherSwitch.turnTetheringOn()
+        }
+    }
+}

--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/shell/ShellTetherSwitch.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/shell/ShellTetherSwitch.kt
@@ -2,6 +2,7 @@ package com.matkosmoljan.apps.autousbtethering.domain.shell
 
 import android.os.Build
 import android.os.Build.VERSION_CODES.*
+import com.matkosmoljan.apps.autousbtethering.FunctionResult
 import com.matkosmoljan.apps.autousbtethering.domain.TetherSwitch
 import java.io.DataOutputStream
 
@@ -17,11 +18,16 @@ class ShellTetherSwitch : TetherSwitch {
         N to 33
     )
 
-    override fun turnTetheringOn() {
+    override fun turnTetheringOn(): FunctionResult<Unit> {
         val methodNumber = getMethodNumber()
         val tetheringShellCommand = TetherSwitchShellCommandGenerator.generateSwitchOnCommand(methodNumber)
+        val isCommandExecutedSuccessfully = executeCommand(tetheringShellCommand)
 
-        executeCommand(tetheringShellCommand)
+        return if (isCommandExecutedSuccessfully) {
+            FunctionResult.Success(Unit)
+        } else {
+            FunctionResult.Failure(IllegalStateException("The tethering shell call hasn't returned successfully"))
+        }
     }
 
     private fun getMethodNumber(): Int {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,12 +8,19 @@
         tools:context=".MainActivity">
 
     <TextView
-            android:layout_width="wrap_content"
+            android:id="@+id/errorMessageView"
+            android:visibility="gone"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="Hello World!"
+            android:text="@string/root_error_message"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+            android:textColor="#ff6666"
+            android:textStyle="bold"
+            android:layout_marginRight="32dp"
+            android:layout_marginLeft="32dp"
+            android:gravity="center"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">Auto USB Tethering</string>
+
+    <string name="root_error_message">The application wasn\'t able to activate USB tethering. Please make sure you have
+        root permissions.
+    </string>
 </resources>


### PR DESCRIPTION
Starts the activity at boot to make sure root is still enabled. The broadcast receiver handles the rest. Seemingly no service is required.

Resolves: #5 
Resolves: #9 