### PR TITLE
Added Support for Android Oreo and Android Pie

### DIFF
--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/shell/ShellCommandGenerator.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/shell/ShellCommandGenerator.kt
@@ -2,8 +2,8 @@ package com.matkosmoljan.apps.autousbtethering.domain.shell
 
 private const val METHOD_NUMBER_PLACEHOLDER = "[METHOD_NUMBER]"
 private const val USB_TETHERING_SWITCH_COMMAND = "su -c service call connectivity $METHOD_NUMBER_PLACEHOLDER i32"
-private const val USB_TETHERING_SWITCH_ON_COMMAND = "$USB_TETHERING_SWITCH_COMMAND 1"
-private const val USB_TETHERING_SWITCH_OFF_COMMAND = "$USB_TETHERING_SWITCH_COMMAND 0"
+private const val USB_TETHERING_SWITCH_ON_COMMAND = "$USB_TETHERING_SWITCH_COMMAND 1 s16 text"
+private const val USB_TETHERING_SWITCH_OFF_COMMAND = "$USB_TETHERING_SWITCH_COMMAND 0 s16 text"
 
 
 /**

--- a/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/shell/ShellTetherSwitch.kt
+++ b/app/src/main/java/com/matkosmoljan/apps/autousbtethering/domain/shell/ShellTetherSwitch.kt
@@ -15,7 +15,9 @@ class ShellTetherSwitch : TetherSwitch {
     private val androidApiVersionToMethodNumbers = mapOf(
         KITKAT to 34,
         LOLLIPOP to 30,
-        N to 33
+        N to 33,
+        O to 34,
+        P to 33
     )
 
     override fun turnTetheringOn(): FunctionResult<Unit> {


### PR DESCRIPTION
This should add support for Android Oreo and Pie based on this StackOverflow answer: https://stackoverflow.com/questions/20226924/is-it-possible-to-usb-tether-an-android-device-using-adb-through-the-terminal/52074712#52074712

This has only been tested on Android Pie yet though (because that's the only test device I have currently), I'm not sure if this still works with the older Android versions (as `USB_TETHERING_SWITCH_COMMAND` has additional parameters)

Great App btw. works like a charm this way.